### PR TITLE
Emergency backup created

### DIFF
--- a/jenkins_backup.sh
+++ b/jenkins_backup.sh
@@ -7,9 +7,10 @@ if [[ -n ${JENKINS_HOME_S3_BUCKET_NAME} ]]; then
   tar --exclude 'war/*' --exclude 'workspace/*' -czf /tmp/jenkins_home.tar.gz .
 
   if [[ -f /tmp/jenkins_home.tar.gz ]]; then
-    aws s3 cp /tmp/jenkins_home.tar.gz s3://${JENKINS_HOME_S3_BUCKET_NAME}/jenkins_home/
+    # Do the copy to a new location so interruptions during copy don't corrupt existing backup
+    aws s3 cp /tmp/jenkins_home.tar.gz s3://${JENKINS_HOME_S3_BUCKET_NAME}/jenkins_home_latest/
+    aws s3 mv s3://${JENKINS_HOME_S3_BUCKET_NAME}/jenkins_home_latest s3://${JENKINS_HOME_S3_BUCKET_NAME}/jenkins_home --recursive
   fi
 else
   echo 'Unable to backup existing jenkins configuration. JENKINS_HOME_S3_BUCKET_NAME is unset.'
 fi
-


### PR DESCRIPTION
See issue 6. Backup script now copies jenkins_home to a new folder in
S3. This stops the existing backup getting corrupted if the copy is
interrupted. Once complete the new backup is moved to the usual location
on S3 - the move operation between S3 locations appears to handle
interruptions cleanly
