### PR TITLE
Bug - Update Jenkins to current build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/centos-base:v0.2.0
+FROM quay.io/ukhomeofficedigital/centos-base:v0.4.0
 
 RUN yum install -y wget && wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm && \
   rpm -ivh epel-release-7-8.noarch.rpm
@@ -7,7 +7,7 @@ RUN yum install -y wget && wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/
 RUN yum install -y -q python-pip java-headless fontconfig dejavu-sans-fonts git parallel which; yum clean all; pip install awscli
 
 # Install jenkins
-ENV JENKINS_VERSION 2.19
+ENV JENKINS_VERSION 2.26
 RUN yum install -y -q http://pkg.jenkins-ci.org/redhat/jenkins-${JENKINS_VERSION}-1.1.noarch.rpm
 
 #ADD docker.repo /etc/yum.repos.d/docker.repo

--- a/plugins.base.txt
+++ b/plugins.base.txt
@@ -26,7 +26,7 @@ momentjs:1.1.1
 build-timeout:1.17.1
 javadoc:1.4
 maven-plugin:2.13
-token-macro:1.12.1
+token-macro:2.0
 script-security:1.22
 handlebars:1.1.1
 branch-api:1.10


### PR DESCRIPTION
Jenkins needs to be greater than 2.19 in order for the groovy splice function to work
